### PR TITLE
test: Run e2e tests as part of PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,7 +72,7 @@ jobs:
         run: npm run build
 
   e2e:
-    name: 'Verify the e2e tests'
+    name: 'Run e2e tests'
     runs-on: ubuntu-latest
     timeout-minutes: 7
     steps:
@@ -83,8 +83,11 @@ jobs:
 
       - uses: bahmutov/npm-install@v1.8.32
 
+      - name: build app
+        run: npm run build
+
       - name: Install Playwright
         run: npx playwright install --with-deps
 
-      - name: build app
+      - name: Run tests
         run: npm run test:e2e

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: bahmutov/npm-install@v1.8.32
 
-      - name: build app
+      - name: Run lint
         run: npm run lint:ci
 
   style:
@@ -53,7 +53,7 @@ jobs:
 
       - uses: bahmutov/npm-install@v1.8.32
 
-      - name: build app
+      - name: Run formatter
         run: npm run format:ci
 
   build:
@@ -70,3 +70,21 @@ jobs:
 
       - name: build app
         run: npm run build
+
+  e2e:
+    name: 'Verify the e2e tests'
+    runs-on: ubuntu-latest
+    timeout-minutes: 7
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - uses: bahmutov/npm-install@v1.8.32
+
+      - name: Install Playwright
+        run: npx playwright install --with-deps
+
+      - name: build app
+        run: npm run test:e2e

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -91,3 +91,19 @@ jobs:
 
       - name: Run tests
         run: npm run test:e2e
+        env:
+          DEBUG: 'pw:webserver'
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: playwright-report
+          path: /playwright-report/
+          retention-days: 30
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: playwright-data
+          path: /playwright-data/
+          retention-days: 30

--- a/e2e/vue.spec.ts
+++ b/e2e/vue.spec.ts
@@ -4,5 +4,5 @@ import { test, expect } from '@playwright/test';
 // https://playwright.dev/docs/intro
 test('visits the app root url', async ({ page }) => {
   await page.goto('/');
-  await expect(page.locator('div.greetings > h1')).toHaveText('You did it!');
+  await expect(page.locator('header')).toHaveText(/sentence scrambler/i);
 })

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:unit": "vitest",
     "test:coverage": "vitest --coverage",
     "test:e2e": "playwright test",
+    "test:e2e:dev": "playwright test --ui",
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,7 +40,9 @@ const config: PlaywrightTestConfig = {
     trace: 'on-first-retry',
 
     /* Only on CI systems run the tests headless */
-    headless: !!process.env.CI
+    headless: !!process.env.CI,
+
+    video: 'retain-on-failure',
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
Get the existing e2e test up and running as a smoke test by updating the label text to match what the app displays.

Beyond that, add setup for running it as part of the PR workflow.