### PR TITLE
ci: use setup action cache

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,8 +20,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
 
-      - uses: bahmutov/npm-install@v1.10.1
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run tests
         run: npm run test:coverage
@@ -35,8 +37,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
 
-      - uses: bahmutov/npm-install@v1.10.1
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run lint
         run: npm run lint:ci
@@ -50,8 +54,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
 
-      - uses: bahmutov/npm-install@v1.10.1
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run formatter
         run: npm run format:ci
@@ -65,8 +71,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
 
-      - uses: bahmutov/npm-install@v1.10.1
+      - name: Install dependencies
+        run: npm ci
 
       - name: build app
         run: npm run build
@@ -80,8 +88,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
 
-      - uses: bahmutov/npm-install@v1.10.1
+      - name: Install dependencies
+        run: npm ci
 
       - name: build app
         run: npm run build


### PR DESCRIPTION
Drop a dependency, favoring the caching provided by the setup action, which is also one of the core actions.

Here is the cache entry it created on a [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) run:
![image](https://github.com/AndrewADev/sentence-scrambler/assets/2937540/cb6889c0-140c-4dc9-b42d-03c276b8b68d)


...and here it is reading from the cache on a repeated run:
![image](https://github.com/AndrewADev/sentence-scrambler/assets/2937540/620b9f85-ebe0-4322-8142-eb7b9da01770)
