### PR TITLE
chore: remove deprecated extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+  "recommendations": ["Vue.volar"]
 }


### PR DESCRIPTION
The official Vue extension (already recommended for project) now recommended instead.
