### PR TITLE
fix(build): Vite CJS warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sentence-scrambler",
   "version": "0.0.0",
+  "type": "module",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: ['./src/views/**/*.{vue,js,ts,jsx,tsx,html}', './src/components/**/*.{vue,,js,ts,jsx,tsx,html}'],
   theme: {
     extend: {},


### PR DESCRIPTION
Add missing type specifier to fix a warning from vite. Also convert settings files to ECMAScript Modules.
